### PR TITLE
支持将 GitHub Release 同步到 Gitee Release

### DIFF
--- a/.github/workflows/gitee.yaml
+++ b/.github/workflows/gitee.yaml
@@ -7,9 +7,9 @@ on:
 
 env:
   GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-  GITEE_OWNER: ${{ env.GITEE_OWNER }}
-  GITEE_REPO: ${{ env.GITEE_REPO }}
-  GITEE_TARGET_COMMITISH: ${{ env.GITEE_TARGET_COMMITISH }}
+  GITEE_OWNER: ${{ vars.GITEE_OWNER }}
+  GITEE_REPO: ${{ vars.GITEE_REPO }}
+  GITEE_TARGET_COMMITISH: ${{ vars.GITEE_TARGET_COMMITISH }}
 
 jobs:
   sync-release-to-gitee:


### PR DESCRIPTION
需要在仓库的 `settings/secrets/actions` 页面添加 Repository secrets

- `GITEE_TOKEN` 在 https://gitee.com/profile/personal_access_tokens 获取
- `GITEE_OWNER` 用户 ID
- `GITEE_REPO` 仓库名称
- `GITEE_TARGET_COMMITISH` 分支名称或者 commit SHA, 默认是当前默认分支

预览：

https://github.com/zkitefly/gitee-release-test/releases

https://gitee.com/bleaker/hmcld/releases