### PR TITLE
在 Linux 平台上静态链接 musl libc

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,13 +89,19 @@ jobs:
           7z a "$source.zip" "$source"
           cat "$source.zip" | gh-actions-artifact-client.js upload "$source"
   build-linux-x86_64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Build for Linux x86_64
+    env:
+      TARGET: x86_64-unknown-linux-musl
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install GitHub Artifact Client
         uses: lhotari/gh-actions-artifact-client@v2
+      - name: Install musl libc
+        run: |
+          sudo apt update
+          sudo apt install --yes --no-install-recommends build-essential musl-tools musl-dev
       - name: Compute Version
         run: |
           if [ -z "${{ github.event.inputs.version }}" ]; then
@@ -105,9 +111,10 @@ jobs:
           fi
       - name: Build
         run: |
-          rustup target add --toolchain nightly x86_64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-          cargo +nightly build --release --target $(rustc --print host-tuple) \
+          rustup target add --toolchain nightly "$TARGET"
+          rustup component add rust-src --toolchain "nightly-$TARGET"
+          rustup component add rust-src --toolchain "nightly-$(rustc --print host-tuple)"
+          cargo +nightly build --release --target "$TARGET" \
             -Z build-std=core,std,alloc,proc_macro,panic_abort \
             -Z build-std-features=default,optimize_for_size
         env:
@@ -116,18 +123,24 @@ jobs:
         run: |
           source="terracotta-${TERRACOTTA_VERSION}-linux-x86_64"
           
-          cp "target/$(rustc --print host-tuple)/release/terracotta" "$source"
+          cp "target/$TARGET/release/terracotta" "$source"
           chmod 755 "$source"
           tar -cf "$source.tar" "$source"
           zip -q - "$source.tar" | gh-actions-artifact-client.js upload "$source.tar"
   build-linux-arm64:
     runs-on: ubuntu-24.04-arm
     name: Build for Linux arm64
+    env:
+      TARGET: aarch64-unknown-linux-musl
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install GitHub Artifact Client
         uses: lhotari/gh-actions-artifact-client@v2
+      - name: Install musl libc
+        run: |
+          sudo apt update
+          sudo apt install --yes --no-install-recommends build-essential musl-tools musl-dev
       - name: Compute Version
         run: |
           if [ -z "${{ github.event.inputs.version }}" ]; then
@@ -137,9 +150,10 @@ jobs:
           fi
       - name: Build
         run: |
-          rustup target add --toolchain nightly aarch64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-aarch64-unknown-linux-gnu
-          cargo +nightly build --release --target $(rustc --print host-tuple) \
+          rustup target add --toolchain nightly "$TARGET"
+          rustup component add rust-src --toolchain "nightly-$TARGET"
+          rustup component add rust-src --toolchain "nightly-$(rustc --print host-tuple)"
+          cargo +nightly build --release --target "$TARGET" \
             -Z build-std=core,std,alloc,proc_macro,panic_abort \
             -Z build-std-features=default,optimize_for_size
         env:
@@ -148,7 +162,7 @@ jobs:
         run: |
           source="terracotta-${TERRACOTTA_VERSION}-linux-arm64"
           
-          cp "target/$(rustc --print host-tuple)/release/terracotta" "$source"
+          cp "target/$TARGET/release/terracotta" "$source"
           chmod 755 "$source"
           tar -cf "$source.tar" "$source"
           zip -q - "$source.tar" | gh-actions-artifact-client.js upload "$source.tar"


### PR DESCRIPTION
本 PR 会使 Linux 平台上的文件体积略微膨胀。

```
> ls -al terracotta-*
-rwxr-xr-x 1 glavo glavo 10029568 10月 21 21:37 terracotta-7314df1-linux-arm64*
-rwxr-xr-x 1 glavo glavo  8367908 10月 21 21:37 terracotta-7314df1-linux-arm64.xz*
-rwxr-xr-x 1 glavo glavo 11742248 10月 21 21:37 terracotta-7314df1-linux-x86_64*
-rwxr-xr-x 1 glavo glavo  9562164 10月 21 21:37 terracotta-7314df1-linux-x86_64.xz*
```

通过 XZ 压缩可以将其压缩回 10MiB 以内。是否有必要上传 XZ 压缩后的文件？