### PR TITLE
修改 macOS `Info.plist`：将应用移出“游戏”分类并取消游戏模式的启用

### DIFF
--- a/build/macos/terracotta.app/Contents/Info.plist
+++ b/build/macos/terracotta.app/Contents/Info.plist
@@ -2,52 +2,52 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>terracotta</string>
-	<key>CFBundleIconFile</key>
-	<string>icon-mac.png</string>
-	<key>CFBundleIdentifier</key>
-	<string>net.burningtnt.terracotta</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>Terracotta</string>
-	<key>CFBundleDisplayName</key>
-	<string>Terracotta</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleVersion</key>
-	<string>1.0</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.12</string>
-	<key>NSMainNibFile</key>
-	<string>MainMenu</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
-	<key>NSAppTransportSecurity</key>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>terracotta</string>
+    <key>CFBundleIconFile</key>
+    <string>icon-mac.png</string>
+    <key>CFBundleIdentifier</key>
+    <string>net.burningtnt.terracotta</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Terracotta</string>
+    <key>CFBundleDisplayName</key>
+    <string>Terracotta</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.12</string>
+    <key>NSMainNibFile</key>
+    <string>MainMenu</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>Allow Terracotta to scan Minecraft LAN Worlds.</string>
-	<key>NSBonjourServices</key>
-	<array>
-		<string>_terracotta._udp</string>
-	</array>
-	<key>CFBundleGetInfoString</key>
-	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>Terracotta</string>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.utilities</string>
-	<key>CFBundleSupportedPlatforms</key>
-	<array>
-		<string>MacOSX</string>
-	</array>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Allow Terracotta to scan Minecraft LAN Worlds.</string>
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_terracotta._udp</string>
+    </array>
+    <key>CFBundleGetInfoString</key>
+    <string>1.0</string>
+    <key>CFBundleSignature</key>
+    <string>Terracotta</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.utilities</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Why?

1. **Terracotta 不是游戏**，且在 macOS 若软件归类为“游戏”会自动存放在启动台的“游戏”文件夹内，可能导致用户希望独立使用软件时找不到，基于 Terracotta 的用途，将其分类到“实用工具”更加合适（启动台不会单独为他存放到其他文件夹）
2. **游戏模式毫无意义**，macOS 下启动游戏模式的基本条件是应用全屏，大部分情况游戏模式不会启动，如果用户在 macOS 下全屏运行陶瓦联机独立程序（虽然是少数，尤其是只有单屏幕的情况下），macOS 会主动向 Terracotta 倾斜性能，可能会间接影响到 MC 的游戏性能发挥，尤其是 HMCL 因分发问题导致游戏无法使用游戏模式的情况下，虽然可以手动关闭

>[!note]
>如果说抛弃独立版本，那么在未来不再包含独立用户界面并且不再往 `Applications` 目录释放应用程序之前，此 PR 依旧需要考虑

## ~Diff 问题：~

~变动这么多行是因为这里的 `Info.plist` 使用了 Xcode 进行编辑，这锅让 Xcode 背~

~核心内容其实还是删除了 `<key>GCSupportsGameMode</key>` 和把 `<string>public.app-category.games</string>` 替换为 `<string>public.app-category.utilities</string>`~