### PR TITLE
修复 FreeBSD x86-64 目标构建失败的问题

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,7 +140,7 @@ jobs:
           version: '13.2'
           shell: bash
           run: |
-            sudo pkg install -y llvm-devel curl
+            sudo pkg install -y llvm-devel curl ca_root_nss
             curl --proto 'https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             export CC=clang
             export CXX=clang++


### PR DESCRIPTION
看起来是 SSL 证书的问题，安装 `ca_root_nss` 这个包就能解决。